### PR TITLE
Update the norway viking rematch artwork

### DIFF
--- a/datas.json
+++ b/datas.json
@@ -124,7 +124,7 @@
     {
       "name": "norway viking rematch version 3",
       "sources": [
-        "https://i.imgur.com/X6IkbbW.png"
+        "https://i.imgur.com/pI4AbjN.png"
       ],
       "x": 824,
       "y": 142


### PR DESCRIPTION
Fixes some pixels that were placed wrong on the purple guy in the previous revision.

Also fix the border to the Orkney flag.

The changed areas are circled in this image:
![1](https://github.com/MeblIkea/NordicPlace/assets/13054375/5d879723-f06d-4ad0-ae9e-4207d76a4012)


JhonnyTheJeccer in the discord helped out with these changes.